### PR TITLE
修正在Mybatis异常时CatMybatisPlugin引发NPE的问题

### DIFF
--- a/src/main/java/net/tomjerry/catmonitor/mybatisext/CatMybatisPlugin.java
+++ b/src/main/java/net/tomjerry/catmonitor/mybatisext/CatMybatisPlugin.java
@@ -75,6 +75,7 @@ public class CatMybatisPlugin implements Interceptor {
             t.setStatus(Transaction.SUCCESS);
         } catch (Exception e) {
             Cat.logError(e);
+            throw e;
         } finally {
             t.complete();
         }


### PR DESCRIPTION
捕获异常后除了记录异常，还应当将异常原样抛出，否则返回的returnObj是null会在后续引发NPE，而且NPE源无法寻找
